### PR TITLE
pubspec | bump hmi_core to 2.1.4 and update version to 1.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: ext_rw
 description: API tools on client side for Dart / Flutter application
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/a-givertzman/dart_ext_rw
 publish_to: none
 
 environment:
-  sdk: '>=3.1.5 <4.0.0'
+  sdk: ">=3.1.5 <4.0.0"
 
 dependencies:
   flutter:
@@ -14,7 +14,7 @@ dependencies:
   hmi_core:
     git:
       url: https://github.com/a-givertzman/hmi_core.git
-      ref: 2.1.2
+      ref: 2.1.4
   uuid: ^4.5.1
   web_socket_channel: ^3.0.1
 
@@ -35,7 +35,7 @@ dev_dependencies:
 # The following section is specific to Flutter packages.
 flutter:
   # assets:
-    # - assets/test/
+  # - assets/test/
   # To add assets to your package, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Closes #33 